### PR TITLE
Добавлен CI для tokenizer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install riscv64-elf-gcc
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-riscv64-unknown-elf
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+
+    - name: Download RARS
+      run: |
+        curl -L -o rars.jar https://github.com/TheThirdOne/rars/releases/download/v1.6/rars1_6.jar
+
+    - name: Build
+      run: python3 build.py
+
+    - name: Run tests
+      run: java -jar rars.jar test_tokenizer.s

--- a/build.py
+++ b/build.py
@@ -48,10 +48,16 @@ class TempFileSystem:
             self.file_manager.remove(file) 
 
 class RiscVCompiler:
+    GCC_NAMES = ["riscv64-elf-gcc", "riscv64-unknown-elf-gcc"]
+
     def __init__(self):
-        self.gcc = shutil.which("riscv64-elf-gcc")
+        self.gcc = None
+        for name in self.GCC_NAMES:
+            self.gcc = shutil.which(name)
+            if self.gcc:
+                break
         if not self.gcc:
-            raise Exception("Cannot find riscv64-elf-gcc")
+            raise Exception("Cannot find riscv64 gcc: tried " + ", ".join(self.GCC_NAMES))
 
     def compile(self, input_file, output_file, include_dirs=None):
         cmd = [


### PR DESCRIPTION
Добавлен CI для базовых тестов токенайзера. Пока нет обработки падения тестов, но можно вручную просматривать их.